### PR TITLE
stack scope alloc cleanup, build cleanups

### DIFF
--- a/include/belle-sip/utils.h
+++ b/include/belle-sip/utils.h
@@ -25,8 +25,8 @@
 #include <errno.h>
 #include "belle-sip/defs.h"
 
-#include "bctoolbox/logging.h"
-#include "bctoolbox/vconnect.h"
+#include <bctoolbox/logging.h>
+#include <bctoolbox/vconnect.h>
 
 #define BELLE_SIP_LOG_DOMAIN "belle-sip"
 

--- a/src/auth_helper.c
+++ b/src/auth_helper.c
@@ -95,16 +95,14 @@ int belle_sip_auth_define_size(const char* algo) {
 }
 
 int belle_sip_auth_helper_compute_ha1_for_algorithm(const char* userid,const char* realm,const char* password, char *ha1, size_t size, const char* algo) {
-    size_t compared_size;
+    size_t di, compared_size, length_byte = (size-1)/2;
+    uint8_t out[length_byte];
+    char *ask;
     compared_size = belle_sip_auth_define_size(algo);
     if (compared_size!= size) {
         belle_sip_error("belle_sip_fill_authorization_header, size of ha1 must be 33 when MD5 or 65 when SHA-256 ");
         return -1;
     }
-    size_t length_byte = (size-1)/2;
-    uint8_t out[length_byte];
-    size_t di;
-    char *ask;
     if (!userid) {
         belle_sip_error("belle_sip_fill_authorization_header, username not found ");
         return -1;
@@ -133,16 +131,14 @@ int belle_sip_auth_helper_compute_ha1(const char* userid,const char* realm,const
 }
 
 int belle_sip_auth_helper_compute_ha2_for_algorithm(const char* method,const char* uri, char *ha2, size_t size, const char* algo) {
-    size_t compared_size;
+    size_t compared_size, length_byte = (size-1)/2, di;
+    uint8_t out[length_byte];
+    char *ask;
     compared_size = belle_sip_auth_define_size(algo);
     if (compared_size!= size) {
         belle_sip_error("belle_sip_fill_authorization_header, size of ha1 must be 33 when MD5 or 65 when SHA-256 ");
         return -1;
     }
-    size_t length_byte = (size-1)/2;
-    uint8_t out[length_byte];
-    size_t di;
-    char *ask;
 	ha2[length_byte*2]='\0';
 	/*HA2=MD5(method:uri)*/
     
@@ -160,16 +156,14 @@ int belle_sip_auth_helper_compute_ha2(const char* method,const char* uri, char h
 }
 
 int belle_sip_auth_helper_compute_response_for_algorithm(const char* ha1,const char* nonce, const char* ha2, char *response, size_t size, const char* algo) {
-    size_t compared_size;
+    size_t di, compared_size, length_byte = (size-1)/2;
+    uint8_t out[length_byte];
+    char *ask;
     compared_size = belle_sip_auth_define_size(algo);
     if (compared_size!= size) {
         belle_sip_error("belle_sip_fill_authorization_header, size of ha1 must be 33 when MD5 or 65 when SHA-256 ");
         return -1;
     }
-    size_t length_byte = (size-1)/2;
-    uint8_t out[length_byte];
-    size_t di;
-    char *ask;
 	response[length_byte*2]='\0';
     
     ask = bctbx_strdup_printf("%s:%s:%s", ha1, nonce, ha2);
@@ -195,17 +189,15 @@ int belle_sip_auth_helper_compute_response_qop_auth_for_algorithm(const char* ha
 													, const char* ha2
                                                     , char *response
                                                     , size_t size, const char* algo) {
-    size_t compared_size;
+    size_t di, compared_size, length_byte = (size-1)/2;
+    uint8_t out[length_byte];
+    char *ask;
+	char nounce_count_as_string[9];
     compared_size = belle_sip_auth_define_size(algo);
     if (compared_size!= size) {
         belle_sip_error("belle_sip_fill_authorization_header, size of ha1 must be 33 when MD5 or 65 when SHA-256 ");
         return -1;
     }
-    size_t length_byte = (size-1)/2;
-    uint8_t out[length_byte];
-    size_t di;
-    char *ask;
-	char nounce_count_as_string[9];
 
 	response[length_byte*2]='\0';
 
@@ -234,19 +226,18 @@ int belle_sip_auth_helper_compute_response_qop_auth(const char* ha1
 int belle_sip_auth_helper_fill_authorization(belle_sip_header_authorization_t* authorization
 											,const char* method
 											,const char* ha1) {
-    size_t size;
+	int auth_mode=0;
+	char* uri;
+	char cnonce[BELLE_SIP_CNONCE_LENGTH + 1];
     const char *algo = belle_sip_header_authorization_get_algorithm(authorization);
-    size = belle_sip_auth_define_size(algo);
+    size_t size = belle_sip_auth_define_size(algo);
     if(!size) {
         belle_sip_error("Algorithm [%s] is not correct ", algo);
         return -1;
-    }
+    }else{
 
-	int auth_mode=0;
-	char* uri;
 	char ha2[size];
 	char response[size];
-	char cnonce[BELLE_SIP_CNONCE_LENGTH + 1];
 
 	response[size-1]=ha2[size-1]='\0';
 
@@ -310,6 +301,7 @@ int belle_sip_auth_helper_fill_authorization(belle_sip_header_authorization_t* a
 	}
 	belle_sip_header_authorization_set_response(authorization,(const char*)response);
 	return 0;
+  }
 }
 
 

--- a/src/provider.c
+++ b/src/provider.c
@@ -1313,8 +1313,9 @@ int belle_sip_provider_add_authorization(belle_sip_provider_t *p, belle_sip_requ
 		/*provides auth info in any cases, usefull even if found because auth info can contain wrong password*/
         if (auth_infos) {
             /*stored to give user information on realm/username which requires authentications*/
+            belle_sip_list_t* elem;
             *auth_infos=belle_sip_list_append(*auth_infos,auth_event);
-            belle_sip_list_t* elem=belle_sip_list_find_double_events(*auth_infos,auth_event);
+            elem=belle_sip_list_find_double_events(*auth_infos,auth_event);
             if(elem!=NULL)
                 *auth_infos=belle_sip_list_delete_link(*auth_infos,elem);
         } else {

--- a/tester/Makefile.am
+++ b/tester/Makefile.am
@@ -51,7 +51,7 @@ AM_LDFLAGS=-no-undefined -export-dynamic
 #AM_LDFLAGS+=-Wl,-rpath -Wl,$(libdir)
 
 
-AM_CFLAGS=$(STRICT_OPTIONS) $(STRICT_OPTIONS_CC)
+AM_CFLAGS=$(STRICT_OPTIONS) $(STRICT_OPTIONS_CC) $(BCTOOLBOX_CFLAGS)
 
 
 test: belle_sip_tester

--- a/tester/auth_helper_tester.c
+++ b/tester/auth_helper_tester.c
@@ -52,6 +52,7 @@ static void test_authentication_sha256(void) {
     belle_sip_header_authorization_set_nonce_count(authorization,1);
     belle_sip_header_authorization_set_qop(authorization,"auth");
     belle_sip_header_authorization_set_cnonce(authorization,"8302210f"); /*for testing purpose*/
+    {
     const char *algo = belle_sip_header_authorization_get_algorithm(authorization);
     BC_ASSERT_EQUAL(0,belle_sip_auth_helper_compute_ha1_for_algorithm("Mufasa","http-auth@example.org","Circle of Life",ha1,size,algo), int, "%d");
     BC_ASSERT_EQUAL(0,belle_sip_auth_helper_fill_authorization(authorization,"REGISTER",ha1), int, "%d");
@@ -60,6 +61,7 @@ static void test_authentication_sha256(void) {
     BC_ASSERT_EQUAL(belle_sip_header_authorization_get_nonce_count(authorization),1, int, "%d");
     belle_sip_object_unref(www_authenticate);
     belle_sip_object_unref(authorization);
+    }
 }
 
 

--- a/tester/belle_sip_register_tester.c
+++ b/tester/belle_sip_register_tester.c
@@ -167,7 +167,7 @@ const char* belle_sip_tester_private_key =
 const char* belle_sip_tester_private_key_passwd="secret";
 
 
-const char *belle_sip_tester_root_ca = 
+const char *belle_sip_tester_root_ca =
 "-----BEGIN CERTIFICATE-----\n"
 "MIIDRjCCAq+gAwIBAgIJAJ3nFcA7qFrOMA0GCSqGSIb3DQEBBQUAMIG7MQswCQYD\n"
 "VQQGEwJGUjETMBEGA1UECAwKU29tZS1TdGF0ZTERMA8GA1UEBwwIR3Jlbm9ibGUx\n"
@@ -230,7 +230,7 @@ static void process_auth_requested(void *user_ctx, belle_sip_auth_event_t *event
         belle_sip_auth_event_set_signing_key(event,key);
         distinguished_name = belle_sip_auth_event_get_distinguished_name(event);
         belle_sip_message("process_auth_requested requested for  DN[%s]",distinguished_name?distinguished_name:"");
-        
+
     } else {
         belle_sip_error("Unexpected auth mode");
     }
@@ -262,7 +262,7 @@ static void process_auth_requested_for_algorithm(void *user_ctx, belle_sip_auth_
         belle_sip_auth_event_set_signing_key(event,key);
         distinguished_name = belle_sip_auth_event_get_distinguished_name(event);
         belle_sip_message("process_auth_requested requested for  DN[%s]",distinguished_name?distinguished_name:"");
-        
+
     } else {
         belle_sip_error("Unexpected auth mode");
     }
@@ -270,11 +270,11 @@ static void process_auth_requested_for_algorithm(void *user_ctx, belle_sip_auth_
 
 int register_before_all(void) {
 	belle_sip_listening_point_t *lp;
-	stack=belle_sip_stack_new(NULL);
     const char* client[2] = {NULL, NULL};
+	stack=belle_sip_stack_new(NULL);
 	if (userhostsfile)
 		belle_sip_stack_set_dns_user_hosts_file(stack,userhostsfile);
-	
+
 	lp=belle_sip_stack_create_listening_point(stack,"0.0.0.0",7060,"UDP");
 	prov=belle_sip_stack_create_provider(stack,lp);
 
@@ -283,7 +283,7 @@ int register_before_all(void) {
 	lp=belle_sip_stack_create_listening_point(stack,"0.0.0.0",7061,"TLS");
 	if (lp) {
 		belle_tls_crypto_config_t *crypto_config=belle_tls_crypto_config_new();
-	
+
 		belle_tls_crypto_config_set_root_ca_data(crypto_config, belle_sip_tester_root_ca);
 		belle_sip_tls_listening_point_set_crypto_config(BELLE_SIP_TLS_LISTENING_POINT(lp), crypto_config);
 		belle_sip_provider_add_listening_point(prov,lp);
@@ -298,7 +298,7 @@ int register_before_all(void) {
 	listener_callbacks.process_transaction_terminated=process_transaction_terminated;
 	listener_callbacks.process_auth_requested=process_auth_requested_for_algorithm;
 	listener_callbacks.listener_destroyed=NULL;
-    
+
 	listener=belle_sip_listener_create_from_callbacks(&listener_callbacks,client);
 	return 0;
 }
@@ -504,7 +504,7 @@ static void stateful_register_tls(void){
 
 static void stateful_register_tls_with_wrong_cname(void){
 	belle_sip_request_t *req;
-	
+
 	req = try_register_user_at_domain(stack, prov, "tls", 1, "tester",test_domain, test_with_wrong_cname, 0);
 	if (req) belle_sip_object_unref(req);
 }
@@ -644,10 +644,10 @@ static void test_channel_moving_to_error_and_cleaned(void){
 		belle_sip_client_transaction_t *tr;
 		char identity[128];
 		char uri[128];
-		
+
 		belle_sip_listening_point_clean_channels(lp);
 		BC_ASSERT_EQUAL(belle_sip_listening_point_get_channel_count(lp),0,int,"%d");
-		
+
 		snprintf(identity,sizeof(identity),"Tester <sip:%s@%s>","bellesip",test_domain);
 		snprintf(uri,sizeof(uri),"sip:%s",test_domain);
 		req = belle_sip_request_create(
@@ -670,7 +670,7 @@ static void test_channel_moving_to_error_and_cleaned(void){
 		/*we just want to verify that it doesn't crash*/
 		belle_sip_stack_sleep(stack, 1000);
 		belle_sip_object_unref(tr);
-		
+
 	}
 }
 
@@ -842,12 +842,12 @@ static void reuse_nonce_base(const char* outbound) {
 	char outbound_uri[256];
 	/*reset auth context*/
 	prov->auth_contexts = belle_sip_list_free_with_data(prov->auth_contexts,(void(*)(void*))belle_sip_authorization_destroy);
-	
+
 	if (outbound)
 		snprintf(outbound_uri, sizeof(outbound_uri),"sip:%s",outbound);
-	
+
 	register_request=register_user_at_domain(stack, prov, "tcp",1,"marie",outbound,NULL);
-	
+
 	if (register_request) {
 		belle_sip_header_authorization_t * h = NULL;
 		belle_sip_request_t *message_request;
@@ -907,7 +907,7 @@ static void reuse_nonce_base(const char* outbound) {
 
 		/*first nonce created should be reused. this test is only for qop = auth*/
 		message_request=send_message_to(register_request, auth_domain,outbound?belle_sip_uri_parse(outbound_uri):NULL);
-		
+
 		h = BELLE_SIP_HEADER_AUTHORIZATION(belle_sip_message_get_header_by_type(
 				BELLE_SIP_MESSAGE(message_request), belle_sip_header_proxy_authorization_t
 			));
@@ -935,11 +935,11 @@ void register_process_request_event(char *nonce, const belle_sip_request_event_t
 	char *uri_as_string= belle_sip_uri_to_string(belle_sip_request_get_uri(req));
 	belle_sip_response_t * response_msg;
 	belle_sip_server_transaction_t *trans=belle_sip_provider_create_server_transaction(prov, req);
-	
+
 	if (strcasecmp(belle_sip_request_get_method(req), "REGISTER") == 0) {
 		response_code=401;
 	}
-	
+
 	if (	(authorization = belle_sip_message_get_header_by_type(req,belle_sip_header_authorization_t))
 		 || (authorization = BELLE_SIP_HEADER_AUTHORIZATION(belle_sip_message_get_header_by_type(req,belle_sip_header_proxy_authorization_t)))) {
 		 char ha1[33], ha2[33], response[33];
@@ -958,14 +958,14 @@ void register_process_request_event(char *nonce, const belle_sip_request_event_t
 			}
 		}
 	}
-	
+
 	belle_sip_random_token((nonce), NONCE_SIZE);
 	response_msg = belle_sip_response_create_from_request(req, response_code);
-	
+
 	if (response_code == 407 || response_code == 401 ) {
 		belle_sip_header_www_authenticate_t *www_authenticate = 401?belle_sip_header_www_authenticate_new():BELLE_SIP_HEADER_WWW_AUTHENTICATE(belle_sip_header_proxy_authenticate_new());
-	
-		
+
+
 		belle_sip_header_www_authenticate_set_realm(www_authenticate, "sip.linphone.org");
 		belle_sip_header_www_authenticate_set_domain(www_authenticate, "sip:sip.linphone.org");
 		belle_sip_header_www_authenticate_set_scheme(www_authenticate, "Digest");
@@ -976,7 +976,7 @@ void register_process_request_event(char *nonce, const belle_sip_request_event_t
 		belle_sip_header_authentication_info_set_next_nonce(authentication_info, nonce);
 		belle_sip_message_add_header(BELLE_SIP_MESSAGE(response_msg), BELLE_SIP_HEADER(authentication_info));
 	}
-	
+
 	belle_sip_server_transaction_send_response(trans,response_msg);
 }
 
@@ -987,7 +987,7 @@ static void test_register_with_next_nonce(void) {
 	char listening_uri[256];
 	belle_sip_listener_callbacks_t cbs;
 	belle_sip_random_token((nonce), sizeof(nonce));
-	
+
 	cbs.process_dialog_terminated=NULL;
 	cbs.process_io_error=NULL;
 	cbs.process_request_event=(void (*)(void *user_ctx, const belle_sip_request_event_t *event))register_process_request_event;


### PR DESCRIPTION
This patch only fixes compile warnings and build cleanups.

The patch is not so clean with respect to coding-style and possibility of introducing bugs, please review.

Sorry for introducing white-space changes (had to use emacs which forces some cleanup upon file-save).