### PR TITLE
Drive-by typo fixes.

### DIFF
--- a/include/belle-sip/utils.h
+++ b/include/belle-sip/utils.h
@@ -73,6 +73,17 @@ BELLE_SIP_BEGIN_DECLS
 
 #define belle_sip_log_level_enabled(level) bctbx_log_level_enabled(BELLE_SIP_LOG_DOMAIN,level)
 
+#ifndef BELLE_SIP_DEBUG_MODE
+/*
+ * Handy switch to enable debug messages.
+ *
+ * To enable, just change to 1.
+ */
+#if 0
+#define BELLE_SIP_DEBUG_MODE
+#endif
+#endif
+
 #ifdef BELLE_SIP_DEBUG_MODE
 #define belle_sip_debug bctbx_debug
 #else

--- a/include/belle-sip/utils.h
+++ b/include/belle-sip/utils.h
@@ -74,7 +74,7 @@ BELLE_SIP_BEGIN_DECLS
 #define belle_sip_log_level_enabled(level) bctbx_log_level_enabled(BELLE_SIP_LOG_DOMAIN,level)
 
 #ifdef BELLE_SIP_DEBUG_MODE
-#define belle_sip_deb(...) bctbx_debug(...)
+#define belle_sip_debug bctbx_debug
 #else
 
 #define belle_sip_debug(...)

--- a/src/belle_sip_loop.c
+++ b/src/belle_sip_loop.c
@@ -21,6 +21,7 @@
 #include "belle_sip_internal.h"
 #include "bctoolbox/map.h"
 #include <limits.h>
+#include <inttypes.h>
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -690,7 +691,7 @@ static void belle_sip_main_loop_iterate(belle_sip_main_loop_t *ml){
 			if (belle_sip_log_level_enabled(BELLE_SIP_LOG_DEBUG)) {
 				/*to avoid too many traces*/
 				char *objdesc=belle_sip_object_to_string((belle_sip_object_t*)s);
-				belle_sip_debug("source %s notified revents=%u, timeout=%i",objdesc,s->revents,(int)s->timeout);
+				belle_sip_debug("source %s notified revents=%u, timeout=%" PRId64,objdesc,s->revents,s->timeout);
 				belle_sip_free(objdesc);
 			}
 

--- a/src/channel.c
+++ b/src/channel.c
@@ -744,7 +744,7 @@ static void update_inactivity_timer(belle_sip_channel_t *obj, int from_recv){
 
 /*constructor for channels creating an outgoing connection
  * bindip local ip address to bind on, typically 0.0.0.0 or ::0
- * locaport locaport to use for binding, can be set to 0 if port doesn't matter
+ * localport local port to use for binding, can be set to 0 if port doesn't matter
  * peer_cname canonical name of remote host, used for TLS verification
  * peername peer's hostname, either ip address or DNS name
  * peer_port peer's port to connect to.

--- a/src/refresher.c
+++ b/src/refresher.c
@@ -180,7 +180,7 @@ belle_sip_header_contact_t* get_first_contact_in_unknown_state(belle_sip_request
 	return NULL;
 }
 
-static int is_contact_address_acurate(const belle_sip_refresher_t* refresher,belle_sip_request_t* request) {
+static int is_contact_address_accurate(const belle_sip_refresher_t* refresher,belle_sip_request_t* request) {
 	belle_sip_header_contact_t* contact;
 	if ((contact = get_first_contact_in_unknown_state(request))){
 		/*check if contact ip/port is consistent with public channel ip/port*/
@@ -268,7 +268,7 @@ static void process_response_event(belle_sip_listener_t *user_ctx, const belle_s
 		if (refresher->state==started) {
 			if (!refresher->first_acknowledged_request)
 				belle_sip_object_ref(refresher->first_acknowledged_request = request);
-			if (is_contact_address_acurate(refresher,request)
+			if (is_contact_address_accurate(refresher,request)
 				|| (!belle_sip_provider_nat_helper_enabled(client_transaction->base.provider) || (contact && belle_sip_parameters_has_parameter(BELLE_SIP_PARAMETERS(contact), "pub-gruu"))) ) { /*Disable nat helper in gruu case. Might not be the best fix, maybe better to make reflesh is not mandatory*/
 				schedule_timer(refresher); /*re-arm timer*/
 			} else {
@@ -760,7 +760,7 @@ int belle_sip_refresher_start(belle_sip_refresher_t* refresher) {
 		if (refresher->target_expires>0) {
 			belle_sip_request_t* request = belle_sip_transaction_get_request(BELLE_SIP_TRANSACTION(refresher->transaction));
 			refresher->state=started;
-			if (is_contact_address_acurate(refresher,request)) {
+			if (is_contact_address_accurate(refresher,request)) {
 				schedule_timer(refresher); /*re-arm timer*/
 			} else {
 				belle_sip_message("belle_sip_refresher_start(): refresher [%p] is resubmitting request because contact sent was not correct in original request.",refresher);

--- a/src/refresher.c
+++ b/src/refresher.c
@@ -183,7 +183,7 @@ belle_sip_header_contact_t* get_first_contact_in_unknown_state(belle_sip_request
 static int is_contact_address_acurate(const belle_sip_refresher_t* refresher,belle_sip_request_t* request) {
 	belle_sip_header_contact_t* contact;
 	if ((contact = get_first_contact_in_unknown_state(request))){
-		/*check if contact ip/port is consistant with  public channel ip/port*/
+		/*check if contact ip/port is consistent with public channel ip/port*/
 		int channel_public_port = refresher->transaction->base.channel->public_port;
 		int contact_port = belle_sip_uri_get_listening_port(belle_sip_header_address_get_uri(BELLE_SIP_HEADER_ADDRESS(contact)));
 		const char* channel_public_ip = refresher->transaction->base.channel->public_ip;


### PR DESCRIPTION
Drive-by typo fixes in comments and function name.

Includes BelledonneCommunications/belle-sip#10, so don't review/merge before the other. I'll rebase this PR as soon as BelledonneCommunications/belle-sip#10 is merged.