### PR TITLE
dns.c: Use struct sockaddr in dns_sa_family

### DIFF
--- a/src/dns/dns.c
+++ b/src/dns/dns.c
@@ -816,7 +816,7 @@ static size_t dns_af_len(int af) {
 	return table[af];
 } /* dns_af_len() */
 
-#define dns_sa_family(sa) (((struct sockaddr_storage *)(sa))->ss_family)
+#define dns_sa_family(sa) (((struct sockaddr *)(sa))->sa_family)
 
 #define dns_sa_len(sa) dns_af_len(dns_sa_family(sa))
 


### PR DESCRIPTION
The allocated object might not be as large as struct sockaddr_storage. Fixes a GCC 13 warning:

```none
dns.c: In function 'dns_ai_setent':
dns.c:679:67: error: array subscript 'struct sockaddr_storage[0]' is partly outside array bounds of 'struct sockaddr[1]' [-Werror=array-bounds=]
  679 | #define dns_sa_family(sa)       (((struct sockaddr_storage *)(sa))->ss_family)
      |                                                                   ^~
dns.c:7465:28: note: object 'sin' of size 16
 7465 |         struct sockaddr_in sin;
      |                            ^~~
dns.c:7466:29: note: object 'sin6' of size 28
 7466 |         struct sockaddr_in6 sin6;
      |                             ^~~~
dns.c:679:67: error: array subscript 'struct sockaddr_storage[0]' is partly outside array bounds of 'struct sockaddr[1]' [-Werror=array-bounds=]
  679 | #define dns_sa_family(sa)       (((struct sockaddr_storage *)(sa))->ss_family)
      |                                                                   ^~
dns.c:7465:28: note: object 'sin' of size 16
 7465 |         struct sockaddr_in sin;
      |                            ^~~
dns.c:7466:29: note: object 'sin6' of size 28
 7466 |         struct sockaddr_in6 sin6;
      |                             ^~~~
```

(Note: line numbers are off because this patch was developed on Fedora's older version.)